### PR TITLE
feat: bitstring status list schema added for revocatin support in MIW…

### DIFF
--- a/BitstringStatusList
+++ b/BitstringStatusList
@@ -1,0 +1,43 @@
+{
+	"@context": {
+		"@protected": true,
+		"BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
+		"BitstringStatusList": {
+			"@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
+			"@context": {
+				"@protected": true,
+				"id": "@id",
+				"type": "@type",
+				"statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+				"encodedList": "https://www.w3.org/ns/credentials/status#encodedList",
+				"ttl": "https://www.w3.org/ns/credentials/status#ttl",
+				"statusReference": "https://www.w3.org/ns/credentials/status#statusReference",
+				"statusSize": "https://www.w3.org/ns/credentials/status#statusSize",
+				"statusMessage": {
+					"@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+					"@context": {
+						"@protected": true,
+						"id": "@id",
+						"type": "@type",
+						"status": "https://www.w3.org/ns/credentials/status#status",
+						"message": "https://www.w3.org/ns/credentials/status#message"
+					}
+				}
+			}
+		},
+		"BitstringStatusListEntry": {
+			"@id": "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
+			"@context": {
+				"@protected": true,
+				"id": "@id",
+				"type": "@type",
+				"statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+				"statusListIndex": "https://www.w3.org/ns/credentials/status#statusListIndex",
+				"statusListCredential": {
+					"@id": "https://www.w3.org/ns/credentials/status#statusListCredential",
+					"@type": "@id"
+				}
+			}
+		}
+	}
+}

--- a/BitstringStatusList.json
+++ b/BitstringStatusList.json
@@ -1,0 +1,43 @@
+{
+	"@context": {
+		"@protected": true,
+		"BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
+		"BitstringStatusList": {
+			"@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
+			"@context": {
+				"@protected": true,
+				"id": "@id",
+				"type": "@type",
+				"statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+				"encodedList": "https://www.w3.org/ns/credentials/status#encodedList",
+				"ttl": "https://www.w3.org/ns/credentials/status#ttl",
+				"statusReference": "https://www.w3.org/ns/credentials/status#statusReference",
+				"statusSize": "https://www.w3.org/ns/credentials/status#statusSize",
+				"statusMessage": {
+					"@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+					"@context": {
+						"@protected": true,
+						"id": "@id",
+						"type": "@type",
+						"status": "https://www.w3.org/ns/credentials/status#status",
+						"message": "https://www.w3.org/ns/credentials/status#message"
+					}
+				}
+			}
+		},
+		"BitstringStatusListEntry": {
+			"@id": "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
+			"@context": {
+				"@protected": true,
+				"id": "@id",
+				"type": "@type",
+				"statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+				"statusListIndex": "https://www.w3.org/ns/credentials/status#statusListIndex",
+				"statusListCredential": {
+					"@id": "https://www.w3.org/ns/credentials/status#statusListCredential",
+					"@type": "@id"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What
`BitStringStatusList` schema JSON added for revocation support in Verifiable credential 

Ref: https://www.w3.org/TR/vc-bitstring-status-list/

### Why

We need to add this URL in side `@context` of revocable credentials